### PR TITLE
Adding boost to use its log system. Fixing warnings.

### DIFF
--- a/Sandbox/premake5.lua
+++ b/Sandbox/premake5.lua
@@ -23,6 +23,11 @@ project "Sandbox"
 	--    "%{IncludeDir.ImGui}",
    }
 
+   libdirs 
+   {
+       "%{LibDir.boost}"
+   }
+
    links 
    {
       "VWolf"

--- a/Sandbox/src/SandboxApplication.cpp
+++ b/Sandbox/src/SandboxApplication.cpp
@@ -5,7 +5,9 @@
 
 class SandboxApplication : public VWolf::Application {
 public:
-	SandboxApplication(): Application(VWolf::DriverType::DirectX12, { 800, 600, "VWolf Sandbox" } ) { }
+	SandboxApplication(): Application(VWolf::DriverType::DirectX12, { 800, 600, "VWolf Sandbox" } ) { 
+		VWOLF_CLIENT_INFO("Initializing VWolf Sandbox");
+	}
 };
 
 VWOLF_MAIN_APP(SandboxApplication)

--- a/VWolf/premake5.lua
+++ b/VWolf/premake5.lua
@@ -28,7 +28,13 @@ project "VWolf"
       "src",
       "%{IncludeDir.GLFW}",
 	  "%{IncludeDir.Glad}",
+      "%{IncludeDir.boost}",
 	--    "%{IncludeDir.ImGui}",
+   }
+
+   libdirs 
+   {
+       "%{LibDir.boost}"
    }
 
 	links 

--- a/VWolf/src/VWolf.h
+++ b/VWolf/src/VWolf.h
@@ -3,3 +3,4 @@
 #include "VWolf/Core/Base.h"
 #include "VWolf/Core/Application.h"
 #include "VWolf/Core/Window.h"
+#include "VWolf/Core/Log.h"

--- a/VWolf/src/VWolf/Core/Application.cpp
+++ b/VWolf/src/VWolf/Core/Application.cpp
@@ -3,21 +3,27 @@
 #include "Driver.h"
 #include "Application.h"
 
+#include "Log.h"
+
 namespace VWolf {
 	Application::Application(DriverType type, InitConfiguration config) : driver(Driver::GetDriver(type))
 	{
+		VWOLF_CORE_INFO("Initializing core application");
 		driver->Initialize(config);
 	}
 
 	Application::~Application()
 	{
+		VWOLF_CORE_INFO("Shutting down core application");
 		driver->Shutdown();
 	}
 
 	void Application::Run() {
+		VWOLF_CORE_INFO("Running core application");
 		// TODO: Replace by events
 		while (!driver->GetWindow()->ShouldClose()) {
 			// TODO: Replace by graphics context
+			VWOLF_CORE_INFO("Clearing window");
 			driver->GetWindow()->Clear();
 		}
 	}	

--- a/VWolf/src/VWolf/Core/Log.cpp
+++ b/VWolf/src/VWolf/Core/Log.cpp
@@ -1,0 +1,147 @@
+#include "vwpch.h"
+
+#include "Log.h"
+
+namespace VWolf {
+
+	BEGIN_DEFINE_PRIVATE
+		BOOST_LOG_ATTRIBUTE_KEYWORD(severity, "Severity", Log::LogSeverity);
+		BOOST_LOG_ATTRIBUTE_KEYWORD(timestamp, "TimeStamp", boost::posix_time::ptime);
+		BOOST_LOG_ATTRIBUTE_KEYWORD(log_thread_id, "ThreadID", boost::log::attributes::current_thread_id::value_type);
+
+		class LogImpl {
+
+			class ColorAttributeImpl: public boost::log::attribute::impl {
+			public:
+				ColorAttributeImpl(Log::LogSeverity severity): severity(severity) {};
+				boost::log::attribute_value get_value()
+				{
+					return boost::log::attributes::make_attribute_value(getColor());
+				}
+				inline void setColor(Log::LogSeverity severity) {
+					this->severity = severity;
+				}
+			private:
+				std::string getColor() {
+					switch (severity)
+					{
+					case Log::LogSeverity::info:
+						return "\033[0m";
+					case Log::LogSeverity::warning:
+						return "\033[33m";
+					case Log::LogSeverity::error:
+					case Log::LogSeverity::fatal:
+						return "\033[31m";
+					case Log::LogSeverity::debug:
+					case Log::LogSeverity::trace:
+						return "\033[32m";
+					default:
+						break;
+					}
+					return "\033[0m";
+				}
+			private:
+				Log::LogSeverity severity;
+			};
+
+			class ColorAttribute : public boost::log::attribute {
+			public:
+				ColorAttribute(ColorAttributeImpl* impl) : boost::log::attribute(impl) {  }
+				explicit ColorAttribute(boost::log::attributes::cast_source const& source) : boost::log::attribute(source.as<ColorAttributeImpl >())
+				{
+				}
+			};
+
+		public:
+
+			static void Init() {
+				if (!initialize) {
+					boost::shared_ptr<std::ostream> stream{ &std::cout, boost::null_deleter{} };
+					auto loggerSink = boost::make_shared<boost::log::sinks::synchronous_sink<boost::log::sinks::text_ostream_backend>>();
+					boost::log::add_common_attributes();
+					loggerSink->locked_backend()->add_stream(stream);
+					loggerSink->locked_backend()->auto_flush(true);
+					loggerSink->set_filter(severity >= minSeverity);
+					loggerSink->set_formatter(boost::log::expressions::stream
+						<< boost::log::expressions::attr<std::string>("Color") << "[" 
+						<< boost::log::expressions::format_date_time(timestamp, "%H:%M:%S.%f") << "] ["
+						<< std::setw(4) << std::left << severity << "] ["
+						<< log_thread_id << "] " <<  "\033[0m"
+						<< boost::log::expressions::smessage
+					);
+
+					boost::log::core::get()->add_sink(loggerSink);
+					initialize = true;
+				}
+			}
+		public:
+			LogImpl() {
+				LogImpl::Init();
+				colorImpl = new ColorAttributeImpl(Log::LogSeverity::debug);
+				logger.add_attribute("Color", ColorAttribute(colorImpl));
+			}
+
+			void setColor(Log::LogSeverity severity) {
+				colorImpl->setColor(severity);
+			}
+		public:
+			static void setSeverityFilter(Log::LogSeverity severity) {
+				minSeverity = severity;
+			}
+		public:
+			boost::log::sources::severity_logger<Log::LogSeverity> logger;
+			static bool initialize;
+		private:
+			ColorAttributeImpl* colorImpl;
+			static Log::LogSeverity minSeverity;
+		};
+
+		bool LogImpl::initialize = false;
+		Log::LogSeverity LogImpl::minSeverity = Log::LogSeverity::trace;
+	END_DEFINE_PRIVATE
+
+	Log Log::coreLog;
+	Log Log::clientLog;
+
+	Log::Log()
+	{
+		_log = new Private::LogImpl();
+	}
+
+	Log::~Log() {
+		delete _log;
+	}
+
+	void Log::Write(LogSeverity severity, const std::string& text)
+	{		
+		_log->setColor(severity);
+		auto record = _log->logger.open_record(boost::log::keywords::severity = severity);	
+		if (record) {
+			boost::log::record_ostream strm(record);
+			strm << text;
+			_log->logger.push_record(boost::move(record));
+		}		
+	}
+
+	void Log::setSeverityFilter(LogSeverity severity)
+	{
+		Private::LogImpl::setSeverityFilter(severity);
+	}
+
+	std::ostream& operator<< (std::ostream& strm, Log::LogSeverity level)
+	{
+		static const std::array<std::string, 6> strings
+		{
+			std::string{"trace"},
+			std::string{"debug"},
+			std::string{"info"},
+			std::string{"warning"},
+			std::string{"error"},
+			std::string{"fatal"}
+		};
+
+		strm << strings[static_cast<std::size_t>(level)];
+
+		return strm;
+	}
+}

--- a/VWolf/src/VWolf/Core/Log.h
+++ b/VWolf/src/VWolf/Core/Log.h
@@ -1,0 +1,57 @@
+#pragma once
+#include "Private.h"
+
+namespace VWolf {
+
+	DECLARE_PRIVATE(LogImpl)
+	
+	class Log {
+	public:
+		enum class LogSeverity {
+			trace,
+			debug,
+			info,
+			warning,
+			error,
+			fatal
+		};
+		Log();
+		~Log();
+
+		void Write(LogSeverity severity, const std::string& text);
+
+		template<typename ... Args>
+		inline void Write(LogSeverity severity, const std::string& format, Args ... args) {
+			int size_s = std::snprintf(nullptr, 0, format.c_str(), args ...) + 1;
+			if (size_s <= 0) { throw std::runtime_error("Error during formatting."); }
+			auto size = static_cast<size_t>(size_s);
+			std::unique_ptr<char[]> buf(new char[size]);
+			std::snprintf(buf.get(), size, format.c_str(), args ...);
+			auto text = std::string(buf.get(), buf.get() + size - 1);
+			this->Write(severity, text);
+		}
+	public:
+		static void setSeverityFilter(LogSeverity severity);
+	public:
+		static Log coreLog;
+		static Log clientLog;		 
+	private:
+		Private::LogImpl* _log;
+	};	
+}
+
+#ifdef VWOLF_CORE
+#define VWOLF_CORE_TRACE(text, ...) ::VWolf::Log::coreLog.Write(::VWolf::Log::LogSeverity::trace, text, __VA_ARGS__)
+#define VWOLF_CORE_DEBUG(text, ...) ::VWolf::Log::coreLog.Write(::VWolf::Log::LogSeverity::debug, text, __VA_ARGS__)
+#define VWOLF_CORE_INFO(text, ...) ::VWolf::Log::coreLog.Write(::VWolf::Log::LogSeverity::info, text, __VA_ARGS__)
+#define VWOLF_CORE_WARNING(text, ...) ::VWolf::Log::coreLog.Write(::VWolf::Log::LogSeverity::warning, text, __VA_ARGS__)
+#define VWOLF_CORE_ERROR(text, ...) ::VWolf::Log::coreLog.Write(::VWolf::Log::LogSeverity::error, text, __VA_ARGS__)
+#define VWOLF_CORE_FATAL(text, ...) ::VWolf::Log::coreLog.Write(::VWolf::Log::LogSeverity::fatal, text, __VA_ARGS__)
+#endif
+
+#define VWOLF_CLIENT_TRACE(text, ...) ::VWolf::Log::clientLog.Write(::VWolf::Log::LogSeverity::trace, text, __VA_ARGS__)
+#define VWOLF_CLIENT_DEBUG(text, ...) ::VWolf::Log::clientLog.Write(::VWolf::Log::LogSeverity::debug, text, __VA_ARGS__)
+#define VWOLF_CLIENT_INFO(text, ...) ::VWolf::Log::clientLog.Write(::VWolf::Log::LogSeverity::info, text, __VA_ARGS__)
+#define VWOLF_CLIENT_WARNING(text, ...) ::VWolf::Log::clientLog.Write(::VWolf::Log::LogSeverity::warning, text, __VA_ARGS__)
+#define VWOLF_CLIENT_ERROR(text, ...) ::VWolf::Log::clientLog.Write(::VWolf::Log::LogSeverity::error, text, __VA_ARGS__)
+#define VWOLF_CLIENT_FATAL(text, ...) ::VWolf::Log::clientLog.Write(::VWolf::Log::LogSeverity::fatal, text, __VA_ARGS__)

--- a/VWolf/src/VWolf/Core/Private.h
+++ b/VWolf/src/VWolf/Core/Private.h
@@ -1,0 +1,5 @@
+#pragma once
+#define DECLARE_PRIVATE(Type) namespace Private { class Type; }
+
+#define BEGIN_DEFINE_PRIVATE namespace Private {
+#define END_DEFINE_PRIVATE }

--- a/VWolf/src/VWolf/Platform/Drivers/OpenGLDriver.cpp
+++ b/VWolf/src/VWolf/Platform/Drivers/OpenGLDriver.cpp
@@ -6,17 +6,17 @@
 
 #include "VWolf/Platform/Windows/GLFWWindow.h"
 
-#define GL_MAJOR_VERSION 4
-#define GL_MINOR_VERSION 6
-#define GL_PROFILE GLFW_OPENGL_CORE_PROFILE
+#define OPENGL_MAJOR_VERSION 4
+#define OPENGL_MINOR_VERSION 6
+#define OPENGL_PROFILE GLFW_OPENGL_CORE_PROFILE
 
 namespace VWolf {
 	void OpenGLDriver::Initialize(InitConfiguration config)
 	{
 		glfwInit();
-		glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, GL_MAJOR_VERSION);
-		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, GL_MINOR_VERSION);
-		glfwWindowHint(GLFW_OPENGL_PROFILE, GL_PROFILE);
+		glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, OPENGL_MAJOR_VERSION);
+		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, OPENGL_MINOR_VERSION);
+		glfwWindowHint(GLFW_OPENGL_PROFILE, OPENGL_PROFILE);
 		//glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 
 		window = new GLFWWindow(config);

--- a/VWolf/src/vwpch.h
+++ b/VWolf/src/vwpch.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#define VWOLF_CORE
+
 #include "VWolf/Core/PlatformDetection.h"
 
 #include <iostream>
@@ -14,6 +16,25 @@
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
+
+// BOOST
+#include <boost/core/null_deleter.hpp>
+
+// BOOST LOG
+#include <boost/log/core.hpp>
+#include <boost/log/common.hpp>
+#include <boost/log/expressions.hpp>
+#include <boost/log/attributes/attribute.hpp>
+#include <boost/log/attributes/attribute_value.hpp>
+#include <boost/log/attributes/attribute_cast.hpp>
+#include <boost/log/sinks/sync_frontend.hpp>
+#include <boost/log/sinks/text_ostream_backend.hpp>
+#include <boost/log/sources/basic_logger.hpp>
+#include <boost/log/sources/record_ostream.hpp>
+#include <boost/log/sources/severity_feature.hpp>
+#include <boost/log/sources/severity_logger.hpp>
+#include <boost/log/utility/setup/common_attributes.hpp>
+#include <boost/log/support/date_time.hpp>
 
 #ifdef VW_PLATFORM_WINDOWS
 #include <Windows.h>
@@ -39,3 +60,5 @@
 #pragma comment(lib, "D3D12.lib")
 #pragma comment(lib, "dxgi.lib")
 #endif
+
+#include "VWolf/Core/Log.h"

--- a/premake5.lua
+++ b/premake5.lua
@@ -16,11 +16,18 @@ workspace "VWolf"
 
 outputdir = "%{cfg.buildcfg}-%{cfg.system}-%{cfg.architecture}"
 
+boostversion = "boost_1_79_0"
+programfiles = "C:/Program Files" -- os.getenv("ProgramFiles") -- Returning C:\Program Files (x86)
+
 -- Include directories relative to root folder (solution directory)
 IncludeDir = {}
 IncludeDir["GLFW"] = "%{wks.location}/VWolf/vendor/GLFW/include"
 IncludeDir["Glad"] = "%{wks.location}/VWolf/vendor/Glad/include"
+IncludeDir["boost"] = "%{programfiles}/boost/%{boostversion}"
 -- IncludeDir["ImGui"] = "vendor/imgui"
+
+LibDir = {}
+LibDir["boost"] = "%{programfiles}/boost/%{boostversion}/stage/lib"
 
 group "Dependencies"
    include "VWolf/vendor/GLFW"


### PR DESCRIPTION
Using boost to create a logger. Missing colors though.

Adding colors to messages.

Fixing the extra space for info. Testing all the precompiler definitions for logs.

Moved the variadic parameters function inside the header for Log.

Renaming implementation class and allowing severity filter.

Minimum severity level.

Adding info logs for core application and client.