### PR TITLE
Referencing the right shadow classes. Moving initialization code somewhere else. Removing code from driver.

### DIFF
--- a/VWolf/src/VWolf.h
+++ b/VWolf/src/VWolf.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "VWolf/Core/PlatformDetection.h"
 #include "VWolf/Core/Base.h"
 #include "VWolf/Core/Application.h"
 #include "VWolf/Core/Window.h"

--- a/VWolf/src/VWolf/Core/Application.cpp
+++ b/VWolf/src/VWolf/Core/Application.cpp
@@ -9,6 +9,7 @@ namespace VWolf {
 	Application::Application(DriverType type, InitConfiguration config) : driver(Driver::GetDriver(type))
 	{
 		VWOLF_CORE_INFO("Initializing core application");
+		VWOLF_CORE_DEBUG("Starting with driver: %s", DriverName(type));
 		driver->Initialize(config);
 	}
 

--- a/VWolf/src/VWolf/Core/Base.h
+++ b/VWolf/src/VWolf/Core/Base.h
@@ -9,7 +9,19 @@ namespace VWolf {
 	};
 
 	enum class DriverType {
+#ifdef VW_PLATFORM_WINDOWS
 		DirectX12,
+#endif
 		OpenGL
 	};
+
+	inline const char* DriverName(DriverType type) {
+		switch (type) {
+#ifdef VW_PLATFORM_WINDOWS
+		case DriverType::DirectX12: return "DirectX 12";
+#endif
+		case DriverType::OpenGL: return "OpenGL";
+		}
+		return "";
+	}
 }

--- a/VWolf/src/VWolf/Platform/Drivers/DirectX12Driver.cpp
+++ b/VWolf/src/VWolf/Platform/Drivers/DirectX12Driver.cpp
@@ -5,339 +5,44 @@
 
 #include "VWolf/Platform/Windows/WinWindow.h"
 
-// TODO: Remove
-#define SwapChainBufferCount 2
-
-// TODO: This could live somewhere else
-struct DirectX12Context {
-	Microsoft::WRL::ComPtr<ID3D12Debug> debugController;
-
-	Microsoft::WRL::ComPtr<IDXGIFactory4> mdxgiFactory;
-	Microsoft::WRL::ComPtr<IDXGISwapChain> mSwapChain;
-	Microsoft::WRL::ComPtr<ID3D12Device> md3dDevice;
-	Microsoft::WRL::ComPtr<ID3D12Fence> mFence;
-
-	UINT mRtvDescriptorSize = 0;
-	UINT mDsvDescriptorSize = 0;
-	UINT mCbvSrvUavDescriptorSize = 0;
-	bool m4xMsaaState = false;    // 4X MSAA enabled
-	UINT m4xMsaaQuality = 0;      // quality level of 4X MSAA
-	UINT64 mCurrentFence = 0;
-	int mCurrBackBuffer = 0;
-
-	Microsoft::WRL::ComPtr<ID3D12CommandQueue> mCommandQueue;
-	Microsoft::WRL::ComPtr<ID3D12CommandAllocator> mDirectCmdListAlloc;
-	Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> mCommandList;
-
-	Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mRtvHeap;
-	Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mDsvHeap;
-
-	Microsoft::WRL::ComPtr<ID3D12Resource> mSwapChainBuffer[2];
-	Microsoft::WRL::ComPtr<ID3D12Resource> mDepthStencilBuffer;
-
-	D3D12_VIEWPORT mScreenViewport;
-	D3D12_RECT mScissorRect;
-};
-
 namespace VWolf {
 	void DirectX12Driver::Initialize(InitConfiguration config)
 	{
-		context = new DirectX12Context();
 		handle = GetModuleHandle(nullptr);
 		window = new WinWindow(handle, config);
-		window->Initialize();
+		window->Initialize();		
 
-#if defined(DEBUG) || defined(_DEBUG) 
-		// Enable the D3D12 debug layer. ????
-		{			
-			ThrowIfFailed(D3D12GetDebugInterface(IID_PPV_ARGS(&context->debugController)));
-			context->debugController->EnableDebugLayer();
-		}
-#endif
+		dx12InitializeDefaultContext(context, config.width, config.height, ((WinWindow*)window)->GetHWND())
 
-		ThrowIfFailed(CreateDXGIFactory1(IID_PPV_ARGS(&context->mdxgiFactory)));
+		// Same for resize
+		dx12ResizeBuffers(context, config.width, config.height);
 
-		// Try to create hardware device.
-		HRESULT hardwareResult = D3D12CreateDevice(
-			nullptr,             // default adapter
-			D3D_FEATURE_LEVEL_11_0,
-			IID_PPV_ARGS(&context->md3dDevice));
-
-		// Fallback to WARP device.
-		if (FAILED(hardwareResult))
-		{
-			Microsoft::WRL::ComPtr<IDXGIAdapter> pWarpAdapter;
-			ThrowIfFailed(context->mdxgiFactory->EnumWarpAdapter(IID_PPV_ARGS(&pWarpAdapter)));
-
-			ThrowIfFailed(D3D12CreateDevice(
-				pWarpAdapter.Get(),
-				D3D_FEATURE_LEVEL_11_0,
-				IID_PPV_ARGS(&context->md3dDevice)));
-		}
-
-		ThrowIfFailed(context->md3dDevice->CreateFence(0, D3D12_FENCE_FLAG_NONE,
-			IID_PPV_ARGS(&context->mFence)));
-
-
-		context->mRtvDescriptorSize = context->md3dDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-		context->mDsvDescriptorSize = context->md3dDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
-		context->mCbvSrvUavDescriptorSize = context->md3dDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-
-		// Check 4X MSAA quality support for our back buffer format.
-	// All Direct3D 11 capable devices support 4X MSAA for all render 
-	// target formats, so we only need to check quality support.
-
-		//D3D_DRIVER_TYPE md3dDriverType = D3D_DRIVER_TYPE_HARDWARE;
-		DXGI_FORMAT mBackBufferFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
-		//DXGI_FORMAT mDepthStencilFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
-
-		D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS msQualityLevels;
-		msQualityLevels.Format = mBackBufferFormat;
-		msQualityLevels.SampleCount = 4;
-		msQualityLevels.Flags = D3D12_MULTISAMPLE_QUALITY_LEVELS_FLAG_NONE;
-		msQualityLevels.NumQualityLevels = 0;
-		ThrowIfFailed(context->md3dDevice->CheckFeatureSupport(
-			D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,
-			&msQualityLevels,
-			sizeof(msQualityLevels)));
-		context->m4xMsaaQuality = msQualityLevels.NumQualityLevels;
-
-		// Command objects
-
-		D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-		queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
-		queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-		ThrowIfFailed(context->md3dDevice->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&context->mCommandQueue)));
-
-		ThrowIfFailed(context->md3dDevice->CreateCommandAllocator(
-			D3D12_COMMAND_LIST_TYPE_DIRECT,
-			IID_PPV_ARGS(context->mDirectCmdListAlloc.GetAddressOf())));
-
-		ThrowIfFailed(context->md3dDevice->CreateCommandList(
-			0,
-			D3D12_COMMAND_LIST_TYPE_DIRECT,
-			context->mDirectCmdListAlloc.Get(), // Associated command allocator
-			nullptr,                   // Initial PipelineStateObject
-			IID_PPV_ARGS(context->mCommandList.GetAddressOf())));
-
-		// Start off in a closed state.  This is because the first time we refer 
-		// to the command list we will Reset it, and it needs to be closed before
-		// calling Reset.
-		context->mCommandList->Close();
-
-		// Swap chains
-		// Release the previous swapchain we will be recreating.
-		context->mSwapChain.Reset();
-
-		DXGI_SWAP_CHAIN_DESC sd;
-		sd.BufferDesc.Width = config.width;
-		sd.BufferDesc.Height = config.height;
-		sd.BufferDesc.RefreshRate.Numerator = 60;
-		sd.BufferDesc.RefreshRate.Denominator = 1;
-		sd.BufferDesc.Format = mBackBufferFormat;
-		sd.BufferDesc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;
-		sd.BufferDesc.Scaling = DXGI_MODE_SCALING_UNSPECIFIED;
-		sd.SampleDesc.Count = context->m4xMsaaState ? 4 : 1;
-		sd.SampleDesc.Quality = context->m4xMsaaState ? (context->m4xMsaaQuality - 1) : 0;
-		sd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-		sd.BufferCount = SwapChainBufferCount;
-		sd.OutputWindow = (HWND)((WinWindow*)window)->GetHWND(); //<----- hwnd
-		sd.Windowed = true;
-		sd.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-		sd.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
-
-		// Note: Swap chain uses queue to perform flush.
-		ThrowIfFailed(context->mdxgiFactory->CreateSwapChain(
-			context->mCommandQueue.Get(),
-			&sd,
-			context->mSwapChain.GetAddressOf()));
-
-		// RTVs and DSVs descriptor heaps
-		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc;
-		rtvHeapDesc.NumDescriptors = SwapChainBufferCount;
-		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-		rtvHeapDesc.NodeMask = 0;
-		ThrowIfFailed(context->md3dDevice->CreateDescriptorHeap(
-			&rtvHeapDesc, IID_PPV_ARGS(context->mRtvHeap.GetAddressOf())));
-
-
-		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc;
-		dsvHeapDesc.NumDescriptors = 1;
-		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-		dsvHeapDesc.NodeMask = 0;
-		ThrowIfFailed(context->md3dDevice->CreateDescriptorHeap(
-			&dsvHeapDesc, IID_PPV_ARGS(context->mDsvHeap.GetAddressOf())));
-
-		auto flush = [this]() {
-			// Advance the fence value to mark commands up to this fence point.
-			this->context->mCurrentFence++;
-
-			// Add an instruction to the command queue to set a new fence point.  Because we 
-			// are on the GPU timeline, the new fence point won't be set until the GPU finishes
-			// processing all the commands prior to this Signal().
-			ThrowIfFailed(this->context->mCommandQueue->Signal(this->context->mFence.Get(), this->context->mCurrentFence));
-
-			// Wait until the GPU has completed commands up to this fence point.
-			if (this->context->mFence->GetCompletedValue() < this->context->mCurrentFence)
-			{
-				HANDLE eventHandle = CreateEventEx(nullptr, false, false, EVENT_ALL_ACCESS);
-
-				// Fire event when GPU hits current fence.  
-				ThrowIfFailed(this->context->mFence->SetEventOnCompletion(this->context->mCurrentFence, eventHandle));
-
-				// Wait until the GPU hits current fence event is fired.
-				WaitForSingleObject(eventHandle, INFINITE);
-				CloseHandle(eventHandle);
-			}
-		};
-
-		auto resize = [this, flush, config, mBackBufferFormat]() {
-			flush();
-			ThrowIfFailed(this->context->mCommandList->Reset(this->context->mDirectCmdListAlloc.Get(), nullptr));
-
-			// Release the previous resources we will be recreating.
-			for (int i = 0; i < SwapChainBufferCount; ++i)
-				this->context->mSwapChainBuffer[i].Reset();
-			this->context->mDepthStencilBuffer.Reset();
-
-			// Resize the swap chain.
-			ThrowIfFailed(this->context->mSwapChain->ResizeBuffers(
-				SwapChainBufferCount,
-				config.width, config.height,
-				mBackBufferFormat,
-				DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH));
-
-			this->context->mCurrBackBuffer = 0;
-
-			CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHeapHandle(this->context->mRtvHeap->GetCPUDescriptorHandleForHeapStart());
-			for (UINT i = 0; i < SwapChainBufferCount; i++)
-			{
-				ThrowIfFailed(this->context->mSwapChain->GetBuffer(i, IID_PPV_ARGS(&this->context->mSwapChainBuffer[i])));
-				this->context->md3dDevice->CreateRenderTargetView(this->context->mSwapChainBuffer[i].Get(), nullptr, rtvHeapHandle);
-				rtvHeapHandle.Offset(1, this->context->mRtvDescriptorSize);
-			}
-
-			// Create the depth/stencil buffer and view.
-			D3D12_RESOURCE_DESC depthStencilDesc;
-			depthStencilDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-			depthStencilDesc.Alignment = 0;
-			depthStencilDesc.Width = config.width;
-			depthStencilDesc.Height = config.height;
-			depthStencilDesc.DepthOrArraySize = 1;
-			depthStencilDesc.MipLevels = 1;
-
-			// Correction 11/12/2016: SSAO chapter requires an SRV to the depth buffer to read from 
-			// the depth buffer.  Therefore, because we need to create two views to the same resource:
-			//   1. SRV format: DXGI_FORMAT_R24_UNORM_X8_TYPELESS
-			//   2. DSV Format: DXGI_FORMAT_D24_UNORM_S8_UINT
-			// we need to create the depth buffer resource with a typeless format.  
-			depthStencilDesc.Format = DXGI_FORMAT_R24G8_TYPELESS;
-
-			depthStencilDesc.SampleDesc.Count = this->context->m4xMsaaState ? 4 : 1;
-			depthStencilDesc.SampleDesc.Quality = this->context->m4xMsaaState ? (this->context->m4xMsaaQuality - 1) : 0;
-			depthStencilDesc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
-			depthStencilDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
-
-			D3D12_CLEAR_VALUE optClear;
-			optClear.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;//mDepthStencilFormat;
-			optClear.DepthStencil.Depth = 1.0f;
-			optClear.DepthStencil.Stencil = 0;
-			ThrowIfFailed(this->context->md3dDevice->CreateCommittedResource(
-				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-				D3D12_HEAP_FLAG_NONE,
-				&depthStencilDesc,
-				D3D12_RESOURCE_STATE_COMMON,
-				&optClear,
-				IID_PPV_ARGS(this->context->mDepthStencilBuffer.GetAddressOf())));
-
-			// Create descriptor to mip level 0 of entire resource using the format of the resource.
-			D3D12_DEPTH_STENCIL_VIEW_DESC dsvDesc;
-			dsvDesc.Flags = D3D12_DSV_FLAG_NONE;
-			dsvDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
-			dsvDesc.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;//mDepthStencilFormat;
-			dsvDesc.Texture2D.MipSlice = 0;
-			this->context->md3dDevice->CreateDepthStencilView(this->context->mDepthStencilBuffer.Get(), &dsvDesc, this->context->mDsvHeap->GetCPUDescriptorHandleForHeapStart());
-
-			// Transition the resource from its initial state to be used as a depth buffer.
-			this->context->mCommandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(this->context->mDepthStencilBuffer.Get(),
-				D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_DEPTH_WRITE));
-
-			// Execute the resize commands.
-			ThrowIfFailed(this->context->mCommandList->Close());
-			ID3D12CommandList* cmdsLists[] = { this->context->mCommandList.Get() };
-			this->context->mCommandQueue->ExecuteCommandLists(_countof(cmdsLists), cmdsLists);
-
-			// Wait until resize is complete.
-			flush();
-
-			// Update the viewport transform to cover the client area.
-			this->context->mScreenViewport.TopLeftX = 0;
-			this->context->mScreenViewport.TopLeftY = 0;
-			this->context->mScreenViewport.Width = static_cast<float>(config.width);
-			this->context->mScreenViewport.Height = static_cast<float>(config.height);
-			this->context->mScreenViewport.MinDepth = 0.0f;
-			this->context->mScreenViewport.MaxDepth = 1.0f;
-
-			this->context->mScissorRect = { 0, 0, config.width, config.height };
-		};
-
-		resize();
-
-		((WinWindow*)window)->clearFunc = [this, flush]() {
-
+		((WinWindow*)window)->clearFunc = [this]() {
 			
-			// Reuse the memory associated with command recording.
-	// We can only reset when the associated command lists have finished execution on the GPU.
-			ThrowIfFailed(this->context->mDirectCmdListAlloc->Reset());
+			dx12ResetCommandListAllocator(this->context);
+			dx12ResetCommandList(this->context);
 
-			// A command list can be reset after it has been added to the command queue via ExecuteCommandList.
-			// Reusing the command list reuses memory.
-			ThrowIfFailed(this->context->mCommandList->Reset(this->context->mDirectCmdListAlloc.Get(), nullptr));
+			dx12SetCommandListClientArea(this->context);
 
 			// Indicate a state transition on the resource usage.
-			this->context->mCommandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(this->context->mSwapChainBuffer[this->context->mCurrBackBuffer].Get(),
-				D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
-
-			// Set the viewport and scissor rect.  This needs to be reset whenever the command list is reset.
-			this->context->mCommandList->RSSetViewports(1, &this->context->mScreenViewport);
-			this->context->mCommandList->RSSetScissorRects(1, &this->context->mScissorRect);
+			dx12ResourceBarrierTransitionForCurrentBackBuffer(context, D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
 			// Clear the back buffer and depth buffer.
-			this->context->mCommandList->ClearRenderTargetView(CD3DX12_CPU_DESCRIPTOR_HANDLE(
-				this->context->mRtvHeap->GetCPUDescriptorHandleForHeapStart(),
-				this->context->mCurrBackBuffer,
-				this->context->mRtvDescriptorSize), DirectX::Colors::LightSteelBlue, 0, nullptr);
-			this->context->mCommandList->ClearDepthStencilView(this->context->mDsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH | D3D12_CLEAR_FLAG_STENCIL, 1.0f, 0, 0, nullptr);
+			dx12ClearRenderTargetView(this->context, DirectX::Colors::Green);
+			dx12ClearDepthStencilView(this->context);
 
 			// Specify the buffers we are going to render to.
-			this->context->mCommandList->OMSetRenderTargets(1, &CD3DX12_CPU_DESCRIPTOR_HANDLE(
-				this->context->mRtvHeap->GetCPUDescriptorHandleForHeapStart(),
-				this->context->mCurrBackBuffer,
-				this->context->mRtvDescriptorSize), true, &this->context->mDsvHeap->GetCPUDescriptorHandleForHeapStart());
+			dx12SetRenderTarget(this->context);
 
 			// Indicate a state transition on the resource usage.
-			this->context->mCommandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(this->context->mSwapChainBuffer[this->context->mCurrBackBuffer].Get(),
-				D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+			dx12ResourceBarrierTransitionForCurrentBackBuffer(context, D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT);
 			
-			
-
-			// Done recording commands.
-			ThrowIfFailed(this->context->mCommandList->Close());
-
-			// Add the command list to the queue for execution.
-			ID3D12CommandList* cmdsLists[] = { this->context->mCommandList.Get() };
-			this->context->mCommandQueue->ExecuteCommandLists(_countof(cmdsLists), cmdsLists);
-
-			// swap the back and front buffers
-			ThrowIfFailed(this->context->mSwapChain->Present(0, 0));
-			this->context->mCurrBackBuffer = (this->context->mCurrBackBuffer + 1) % 2;
-
+			dx12ExecuteCommands(this->context);
+			dx12SwapBuffers(this->context);
 			// Wait until frame commands are complete.  This waiting is inefficient and is
 			// done for simplicity.  Later we will show how to organize our rendering code
 			// so we do not have to wait per frame.
-			flush();
+			dx12Flush(this->context);
 		};
 	}
 

--- a/VWolf/src/VWolf/Platform/Drivers/DirectX12Driver.h
+++ b/VWolf/src/VWolf/Platform/Drivers/DirectX12Driver.h
@@ -4,13 +4,15 @@
 
 struct DirectX12Context;
 
+struct HINSTANCE__;
+
 namespace VWolf {
 	class DirectX12Driver : public Driver {
 	public:
 		virtual void Initialize(InitConfiguration config) override;
 		virtual void Shutdown() override;
 	private:
-		void* handle;
+		HINSTANCE__* handle;
 	protected:
 		DirectX12Context* context;
 	};

--- a/VWolf/src/VWolf/Platform/Windows/WinWindow.cpp
+++ b/VWolf/src/VWolf/Platform/Windows/WinWindow.cpp
@@ -42,7 +42,7 @@ namespace VWolf {
         }
     }
 
-	WinWindow::WinWindow(void* handle, InitConfiguration config): hInstance(handle)
+	WinWindow::WinWindow(HINSTANCE__* handle, InitConfiguration config): hInstance(handle)
 	{
         this->config = config;
         WNDCLASS wndClass = {};
@@ -65,7 +65,7 @@ namespace VWolf {
 
 	void WinWindow::Initialize()
 	{
-        DWORD style = WS_CAPTION | WS_MINIMIZEBOX | WS_SYSMENU | WS_MAXIMIZEBOX;
+        DWORD style = WS_CAPTION | WS_MINIMIZEBOX | WS_SYSMENU | WS_MAXIMIZEBOX | WS_OVERLAPPEDWINDOW;
 
         RECT desktop;
         const HWND hDesktop = GetDesktopWindow();
@@ -91,8 +91,8 @@ namespace VWolf {
             nullptr,
             (HINSTANCE)hInstance,
             this);
-        ShowWindow((HWND)hwnd, SW_SHOW);
-        UpdateWindow((HWND)hwnd);        
+        ShowWindow(hwnd, SW_SHOW);
+        UpdateWindow(hwnd);        
 	}
 
     bool WinWindow::ShouldClose() {
@@ -116,13 +116,13 @@ namespace VWolf {
     LRESULT WinWindow::HandleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam) {
         switch (uMsg) {
         case WM_CLOSE:
-            DestroyWindow((HWND)hwnd);
+            DestroyWindow(hwnd);
             break;
         case WM_DESTROY:
             PostQuitMessage(0);
             return 0;
         }
-        return DefWindowProc((HWND)hwnd, uMsg, wParam, lParam);
+        return DefWindowProc(hwnd, uMsg, wParam, lParam);
     }
 
     bool WinWindow::ProcessMessages() {

--- a/VWolf/src/VWolf/Platform/Windows/WinWindow.h
+++ b/VWolf/src/VWolf/Platform/Windows/WinWindow.h
@@ -1,10 +1,13 @@
 #pragma once
 #include "VWolf/Core/Window.h"
 
+struct HWND__;
+struct HINSTANCE__;
+
 namespace VWolf {
 	class WinWindow : public Window {
 	public: // Inherits
-		WinWindow(void* handle, InitConfiguration config);
+		WinWindow(HINSTANCE__* handle, InitConfiguration config);
 		virtual ~WinWindow() override;
 		virtual void Initialize() override;
 		//TODO: Remove
@@ -12,15 +15,15 @@ namespace VWolf {
 		virtual void Clear() override;
 	public: 
 		LRESULT HandleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam);
-		void* GetHWND() { return hwnd; };
+		HWND__* GetHWND() { return hwnd; };
 		// TODO: Remove
 		std::function<void()> clearFunc;
 	private:
 		// TODO: Not sure if I want this here. For now I'll leave it.
 		bool ProcessMessages();
 	private: 
-		void* hwnd = nullptr;
-		void* hInstance = nullptr;
+		HWND__* hwnd = nullptr;
+		HINSTANCE__* hInstance = nullptr;
 		InitConfiguration config;	
 
 	};

--- a/VWolf/src/vwpch.h
+++ b/VWolf/src/vwpch.h
@@ -41,20 +41,14 @@
 #include <wrl.h>
 #include <dxgi1_4.h>
 #include <d3d12.h>
-#include <d3dx12.h>
-//#include <D3Dcompiler.h>
-//#include <DirectXMath.h>
-//#include <DirectXPackedVector.h>
+#include <DirectXMath.h>
 #include <DirectXColors.h>
+#include <d3dx12.h>
+#include <d3dx12Context.h>
+#include <d3dx12Commands.h>
+//#include <D3Dcompiler.h>
+//#include <DirectXPackedVector.h>
 //#include <DirectXCollision.h>
-
-#ifndef ThrowIfFailed
-#define ThrowIfFailed(x) \
-{ \
-    HRESULT hr__ = (x); \
-    if(FAILED(hr__)) { std::cout << "DirectX 12 Error: File" << __FILE__ << ". Line: " << __LINE__ << std::endl; return; } \
-}
-#endif
 
 #pragma comment(lib,"d3dcompiler.lib")
 #pragma comment(lib, "D3D12.lib")

--- a/VWolf/vendor/d3dx12/d3dx12Commands.h
+++ b/VWolf/vendor/d3dx12/d3dx12Commands.h
@@ -1,0 +1,74 @@
+#ifndef __D3DX12_COMMANDS_H__
+#define __D3DX12_COMMANDS_H__
+
+#include <Windows.h>
+#include <wrl.h>
+#include <DirectXMath.h>
+#include "d3dx12.h"
+#include "d3dx12Context.h"
+
+#if defined( __cplusplus )
+
+inline void dx12CreateRenderTargetView(DirectX12Context* context) {
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHeapHandle(context->mRtvHeap->GetCPUDescriptorHandleForHeapStart());
+	for (UINT i = 0; i < SwapChainBufferCount; i++)
+	{
+		ThrowIfFailed(context->mSwapChain->GetBuffer(i, IID_PPV_ARGS(&context->mSwapChainBuffer[i])));
+		context->md3dDevice->CreateRenderTargetView(context->mSwapChainBuffer[i].Get(), nullptr, rtvHeapHandle);
+		rtvHeapHandle.Offset(1, context->mRtvDescriptorSize);
+	}
+}
+
+inline void dx12ResourceBarrierTransition(DirectX12Context* context, ID3D12Resource* resource, D3D12_RESOURCE_STATES from, D3D12_RESOURCE_STATES to) {
+	context->mCommandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(resource,
+		from, to));
+}
+
+// Transition the resource from its initial state to be used as a depth buffer.
+inline void dx12ResourceBarrierTransitionForDepthStencilBuffer(DirectX12Context* context, D3D12_RESOURCE_STATES from, D3D12_RESOURCE_STATES to) {
+	dx12ResourceBarrierTransition(context, context->mDepthStencilBuffer.Get(), from, to);
+}
+
+inline void dx12ResourceBarrierTransitionForCurrentBackBuffer(DirectX12Context* context, D3D12_RESOURCE_STATES from, D3D12_RESOURCE_STATES to) {
+	dx12ResourceBarrierTransition(context, dx12GetCurrentBackBuffer(context), from, to);
+}
+
+inline D3D12_CPU_DESCRIPTOR_HANDLE dx12GetCurrentBackBufferView(DirectX12Context* context) {
+	return CD3DX12_CPU_DESCRIPTOR_HANDLE(
+		context->mRtvHeap->GetCPUDescriptorHandleForHeapStart(),
+		context->mCurrBackBuffer,
+		context->mRtvDescriptorSize);
+}
+
+inline void dx12ClearRenderTargetView(DirectX12Context* context, DirectX::XMVECTORF32 color) {
+	context->mCommandList->ClearRenderTargetView(dx12GetCurrentBackBufferView(context), color, 0, nullptr);
+}
+
+inline void dx12ClearDepthStencilView(DirectX12Context* context) {
+	context->mCommandList->ClearDepthStencilView(context->mDsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH | D3D12_CLEAR_FLAG_STENCIL, 1.0f, 0, 0, nullptr);
+}
+
+inline void dx12SetRenderTarget(DirectX12Context* context) {
+	context->mCommandList->OMSetRenderTargets(1, &dx12GetCurrentBackBufferView(context), true, &context->mDsvHeap->GetCPUDescriptorHandleForHeapStart());
+}
+
+inline void dx12ResizeBuffers(DirectX12Context* context, UINT width, UINT height) {
+	dx12Flush(context);
+	dx12ResetCommandList(context);
+	dx12ResizeSwapChainBuffers(context, width, height);
+
+	dx12CreateRenderTargetView(context);
+
+	dx12CreateDepthStencilBuffer(context, width, height, CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT));
+	dx12CreateDepthStencilView(context);
+
+	dx12ResourceBarrierTransitionForDepthStencilBuffer(context, D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_DEPTH_WRITE);
+
+	dx12ExecuteCommands(context);
+	// Wait until resize is complete.
+	dx12Flush(context);
+	dx12UpdateClientArea(context, width, height);
+}
+
+#endif // #if defined( __cplusplus )
+#endif // #define __D3DX12_COMMANDS_H__

--- a/VWolf/vendor/d3dx12/d3dx12Context.h
+++ b/VWolf/vendor/d3dx12/d3dx12Context.h
@@ -1,0 +1,340 @@
+#ifndef __D3DX12_CONTEXT_H__
+#define __D3DX12_CONTEXT_H__
+
+#include <Windows.h>
+#include <wrl.h>
+#include <d3d12.h>
+
+#if defined( __cplusplus )
+
+#ifndef ThrowIfFailed
+#define ThrowIfFailed(x) \
+{ \
+    HRESULT hr__ = (x); \
+    if(FAILED(hr__)) { std::cout << "DirectX 12 Error: File" << __FILE__ << ". Line: " << __LINE__ << std::endl; return; } \
+}
+#endif
+
+#define SwapChainBufferCount 2
+
+struct DirectX12Context {
+	// For debug purposes
+	Microsoft::WRL::ComPtr<ID3D12Debug> debugController;
+
+	// For device purposes
+	Microsoft::WRL::ComPtr<IDXGIFactory4> mdxgiFactory;
+	Microsoft::WRL::ComPtr<IDXGISwapChain> mSwapChain;
+	Microsoft::WRL::ComPtr<ID3D12Device> md3dDevice;
+	Microsoft::WRL::ComPtr<ID3D12Fence> mFence;
+
+	UINT mRtvDescriptorSize = 0;
+	UINT mDsvDescriptorSize = 0;
+	UINT mCbvSrvUavDescriptorSize = 0;
+	UINT m4xMsaaQuality = 0;      // quality level of 4X MSAA
+	UINT64 mCurrentFence = 0;
+	int mCurrBackBuffer = 0;
+	bool m4xMsaaState = false;    // 4X MSAA enabled		
+
+	// For command queue purposes
+	Microsoft::WRL::ComPtr<ID3D12CommandQueue> mCommandQueue;
+	Microsoft::WRL::ComPtr<ID3D12CommandAllocator> mDirectCmdListAlloc;
+	Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> mCommandList;
+
+	Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mRtvHeap;
+	Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mDsvHeap;
+
+	Microsoft::WRL::ComPtr<ID3D12Resource> mSwapChainBuffer[2];
+	Microsoft::WRL::ComPtr<ID3D12Resource> mDepthStencilBuffer;
+
+	D3D12_VIEWPORT mScreenViewport;
+	D3D12_RECT mScissorRect;
+
+	D3D_DRIVER_TYPE md3dDriverType = D3D_DRIVER_TYPE_HARDWARE;		
+	DXGI_FORMAT mDepthStencilFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
+	DXGI_FORMAT mBackBufferFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
+};
+
+inline void dx12InitializingDeviceInfo(DirectX12Context* context) {
+#if defined(DEBUG) || defined(_DEBUG) 
+	// Enable the D3D12 debug layer. ????
+	{
+		ThrowIfFailed(D3D12GetDebugInterface(IID_PPV_ARGS(&context->debugController)));
+		context->debugController->EnableDebugLayer();
+	}
+#endif
+
+	ThrowIfFailed(CreateDXGIFactory1(IID_PPV_ARGS(&context->mdxgiFactory)));
+
+	// Try to create hardware device.
+	HRESULT hardwareResult = D3D12CreateDevice(
+		nullptr,             // default adapter
+		D3D_FEATURE_LEVEL_11_0,
+		IID_PPV_ARGS(&context->md3dDevice));
+
+	// Fallback to WARP device.
+	if (FAILED(hardwareResult))
+	{
+		Microsoft::WRL::ComPtr<IDXGIAdapter> pWarpAdapter;
+		ThrowIfFailed(context->mdxgiFactory->EnumWarpAdapter(IID_PPV_ARGS(&pWarpAdapter)));
+
+		ThrowIfFailed(D3D12CreateDevice(
+			pWarpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&context->md3dDevice)));
+	}
+
+	ThrowIfFailed(context->md3dDevice->CreateFence(0, D3D12_FENCE_FLAG_NONE,
+		IID_PPV_ARGS(&context->mFence)));
+}
+
+inline void dx12InitializeDescriptorSizes(DirectX12Context* context) {
+	context->mRtvDescriptorSize = context->md3dDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	context->mDsvDescriptorSize = context->md3dDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
+	context->mCbvSrvUavDescriptorSize = context->md3dDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+}
+
+inline void dx12SettingMSAA(DirectX12Context* context, 
+	UINT sampleCount,
+	D3D12_MULTISAMPLE_QUALITY_LEVEL_FLAGS flags = D3D12_MULTISAMPLE_QUALITY_LEVELS_FLAG_NONE) {
+	// Check 4X MSAA quality support for our back buffer format.
+	// All Direct3D 11 capable devices support 4X MSAA for all render 
+	// target formats, so we only need to check quality support.
+	D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS msQualityLevels;
+	msQualityLevels.Format = context->mBackBufferFormat;
+	msQualityLevels.SampleCount = sampleCount;
+	msQualityLevels.Flags = flags;
+	msQualityLevels.NumQualityLevels = 0;
+	ThrowIfFailed(context->md3dDevice->CheckFeatureSupport(
+		D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,
+		&msQualityLevels,
+		sizeof(msQualityLevels)));
+	context->m4xMsaaQuality = msQualityLevels.NumQualityLevels;
+}
+
+inline void dx12InitializeCommandObjects(DirectX12Context* context, 
+	D3D12_COMMAND_LIST_TYPE type = D3D12_COMMAND_LIST_TYPE_DIRECT, 
+	D3D12_COMMAND_QUEUE_FLAGS flags = D3D12_COMMAND_QUEUE_FLAG_NONE) {
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Type = type;
+	queueDesc.Flags = flags;
+	ThrowIfFailed(context->md3dDevice->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&context->mCommandQueue)));
+
+	ThrowIfFailed(context->md3dDevice->CreateCommandAllocator(
+		type,
+		IID_PPV_ARGS(context->mDirectCmdListAlloc.GetAddressOf())));
+
+	ThrowIfFailed(context->md3dDevice->CreateCommandList(
+		0,
+		type,
+		context->mDirectCmdListAlloc.Get(), // Associated command allocator
+		nullptr,                   // Initial PipelineStateObject
+		IID_PPV_ARGS(context->mCommandList.GetAddressOf())));
+
+	// Start off in a closed state.  This is because the first time we refer 
+	// to the command list we will Reset it, and it needs to be closed before
+	// calling Reset.
+	context->mCommandList->Close();
+}
+
+inline void dx12CreateSwapChain(DirectX12Context* context,
+	UINT width,
+	UINT height,
+	HWND window,
+	UINT swapChainBufferCount = 2,
+	DXGI_MODE_SCANLINE_ORDER scanlineOrderMode = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED,
+	DXGI_MODE_SCALING scalingMode = DXGI_MODE_SCALING_UNSPECIFIED,
+	DXGI_SWAP_EFFECT swapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD,
+	DXGI_SWAP_CHAIN_FLAG flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH) {
+	// Swap chains
+		// Release the previous swapchain we will be recreating.
+	context->mSwapChain.Reset();
+
+	DXGI_SWAP_CHAIN_DESC sd;
+	sd.BufferDesc.Width = width;
+	sd.BufferDesc.Height = height;
+	sd.BufferDesc.RefreshRate.Numerator = 60;
+	sd.BufferDesc.RefreshRate.Denominator = 1;
+	sd.BufferDesc.Format = context->mBackBufferFormat;
+	sd.BufferDesc.ScanlineOrdering = scanlineOrderMode;
+	sd.BufferDesc.Scaling = scalingMode;
+	sd.SampleDesc.Count = context->m4xMsaaState ? 4 : 1;
+	sd.SampleDesc.Quality = context->m4xMsaaState ? (context->m4xMsaaQuality - 1) : 0;
+	sd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	sd.BufferCount = swapChainBufferCount;
+	sd.OutputWindow = window; //<----- hwnd
+	sd.Windowed = true;
+	sd.SwapEffect = swapEffect;
+	sd.Flags = flags;
+
+	// Note: Swap chain uses queue to perform flush.
+	ThrowIfFailed(context->mdxgiFactory->CreateSwapChain(
+		context->mCommandQueue.Get(),
+		&sd,
+		context->mSwapChain.GetAddressOf()));
+}
+
+// For RTVs and DSVs descriptor heaps
+inline void dx12InitializeDescriptorHeap(Microsoft::WRL::ComPtr<ID3D12Device> md3dDevice,
+	Microsoft::WRL::ComPtr<ID3D12DescriptorHeap>& mHeap,
+	UINT numDescriptors,
+	D3D12_DESCRIPTOR_HEAP_TYPE type,
+	D3D12_DESCRIPTOR_HEAP_FLAGS flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE) {
+	D3D12_DESCRIPTOR_HEAP_DESC heapDesc;
+	heapDesc.NumDescriptors = numDescriptors;
+	heapDesc.Type = type;
+	heapDesc.Flags = flags;
+	heapDesc.NodeMask = 0;
+	ThrowIfFailed(md3dDevice->CreateDescriptorHeap(
+		&heapDesc, IID_PPV_ARGS(mHeap.GetAddressOf())));
+}
+
+#define dx12InitializeDefaultContext(context, width, height, hwnd) \
+context = new DirectX12Context(); \
+dx12InitializingDeviceInfo(context); \
+dx12InitializeDescriptorSizes(context); \
+dx12SettingMSAA(context, 4); \
+dx12InitializeCommandObjects(context); \
+dx12CreateSwapChain(context, width, height, hwnd, SwapChainBufferCount); \
+dx12InitializeDescriptorHeap(context->md3dDevice, context->mRtvHeap, SwapChainBufferCount, D3D12_DESCRIPTOR_HEAP_TYPE_RTV); \
+dx12InitializeDescriptorHeap(context->md3dDevice, context->mDsvHeap, 1, D3D12_DESCRIPTOR_HEAP_TYPE_DSV);\
+
+inline void dx12Flush(DirectX12Context* context) {
+	// Advance the fence value to mark commands up to this fence point.
+	context->mCurrentFence++;
+
+	// Add an instruction to the command queue to set a new fence point.  Because we 
+	// are on the GPU timeline, the new fence point won't be set until the GPU finishes
+	// processing all the commands prior to this Signal().
+	ThrowIfFailed(context->mCommandQueue->Signal(context->mFence.Get(), context->mCurrentFence));
+
+	// Wait until the GPU has completed commands up to this fence point.
+	if (context->mFence->GetCompletedValue() < context->mCurrentFence)
+	{
+		HANDLE eventHandle = CreateEventEx(nullptr, false, false, EVENT_ALL_ACCESS);
+
+		// Fire event when GPU hits current fence.  
+		ThrowIfFailed(context->mFence->SetEventOnCompletion(context->mCurrentFence, eventHandle));
+
+		// Wait until the GPU hits current fence event is fired.
+		WaitForSingleObject(eventHandle, INFINITE);
+		CloseHandle(eventHandle);
+	}
+}
+
+inline void dx12ExecuteCommands(DirectX12Context* context) {
+	// Execute the resize commands.
+	ThrowIfFailed(context->mCommandList->Close());
+	ID3D12CommandList* cmdsLists[] = { context->mCommandList.Get() };
+	context->mCommandQueue->ExecuteCommandLists(_countof(cmdsLists), cmdsLists);
+}
+
+inline void dx12SwapBuffers(DirectX12Context* context) {
+	// swap the back and front buffers
+	ThrowIfFailed(context->mSwapChain->Present(0, 0));
+	context->mCurrBackBuffer = (context->mCurrBackBuffer + 1) % 2;
+}
+
+inline void dx12CreateDepthStencilBuffer(DirectX12Context* context, UINT width, UINT height, D3D12_HEAP_PROPERTIES properties) {
+	// Create the depth/stencil buffer and view.
+	D3D12_RESOURCE_DESC depthStencilDesc;
+	depthStencilDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+	depthStencilDesc.Alignment = 0;
+	depthStencilDesc.Width = width;
+	depthStencilDesc.Height = height;
+	depthStencilDesc.DepthOrArraySize = 1;
+	depthStencilDesc.MipLevels = 1;
+
+	// Correction 11/12/2016: SSAO chapter requires an SRV to the depth buffer to read from 
+	// the depth buffer.  Therefore, because we need to create two views to the same resource:
+	//   1. SRV format: DXGI_FORMAT_R24_UNORM_X8_TYPELESS
+	//   2. DSV Format: DXGI_FORMAT_D24_UNORM_S8_UINT
+	// we need to create the depth buffer resource with a typeless format.  
+	depthStencilDesc.Format = DXGI_FORMAT_R24G8_TYPELESS;
+
+	depthStencilDesc.SampleDesc.Count = context->m4xMsaaState ? 4 : 1;
+	depthStencilDesc.SampleDesc.Quality = context->m4xMsaaState ? (context->m4xMsaaQuality - 1) : 0;
+	depthStencilDesc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+	depthStencilDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
+
+	D3D12_CLEAR_VALUE optClear;
+	optClear.Format = context->mDepthStencilFormat;
+	optClear.DepthStencil.Depth = 1.0f;
+	optClear.DepthStencil.Stencil = 0;
+	ThrowIfFailed(context->md3dDevice->CreateCommittedResource(
+		&properties,
+		D3D12_HEAP_FLAG_NONE,
+		&depthStencilDesc,
+		D3D12_RESOURCE_STATE_COMMON,
+		&optClear,
+		IID_PPV_ARGS(context->mDepthStencilBuffer.GetAddressOf())));
+}
+
+inline D3D12_CPU_DESCRIPTOR_HANDLE dx12GetDepthStencilView(DirectX12Context* context) {
+	return context->mDsvHeap->GetCPUDescriptorHandleForHeapStart();
+}
+
+inline void dx12CreateDepthStencilView(DirectX12Context* context) {
+	// Create descriptor to mip level 0 of entire resource using the format of the resource.
+	D3D12_DEPTH_STENCIL_VIEW_DESC dsvDesc;
+	dsvDesc.Flags = D3D12_DSV_FLAG_NONE;
+	dsvDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+	dsvDesc.Format = context->mDepthStencilFormat;
+	dsvDesc.Texture2D.MipSlice = 0;
+	context->md3dDevice->CreateDepthStencilView(context->mDepthStencilBuffer.Get(), &dsvDesc, dx12GetDepthStencilView(context));
+}
+
+inline void dx12ResetCommandList(DirectX12Context* context) {
+	// A command list can be reset after it has been added to the command queue via ExecuteCommandList.
+			// Reusing the command list reuses memory.
+	ThrowIfFailed(context->mCommandList->Reset(context->mDirectCmdListAlloc.Get(), nullptr));
+}
+
+inline void dx12ResetCommandListAllocator(DirectX12Context* context) {			
+	// Reuse the memory associated with command recording.
+	// We can only reset when the associated command lists have finished execution on the GPU.
+	ThrowIfFailed(context->mDirectCmdListAlloc->Reset());
+}
+
+inline void dx12ResetSwapChainBuffers(DirectX12Context* context, int swapChains) {
+	// Release the previous resources we will be recreating.
+	for (int i = 0; i < swapChains; ++i)
+		context->mSwapChainBuffer[i].Reset();
+	context->mDepthStencilBuffer.Reset();
+	context->mCurrBackBuffer = 0;
+}
+
+inline void dx12ResizeSwapChainBuffers(DirectX12Context* context, UINT width, UINT height) {
+	dx12ResetSwapChainBuffers(context, SwapChainBufferCount);
+	// Resize the swap chain.
+	ThrowIfFailed(context->mSwapChain->ResizeBuffers(
+		SwapChainBufferCount,
+		width, height,
+		context->mBackBufferFormat,
+		DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH));
+}
+
+inline void dx12UpdateClientArea(DirectX12Context* context, UINT width, UINT height) {
+	// Update the viewport transform to cover the client area.
+	context->mScreenViewport.TopLeftX = 0;
+	context->mScreenViewport.TopLeftY = 0;
+	context->mScreenViewport.Width = static_cast<float>(width);
+	context->mScreenViewport.Height = static_cast<float>(height);
+	context->mScreenViewport.MinDepth = 0.0f;
+	context->mScreenViewport.MaxDepth = 1.0f;
+
+	// Does it have to be long?
+	context->mScissorRect = { 0, 0, static_cast<long>(width), static_cast<long>(height) };
+}
+
+inline void dx12SetCommandListClientArea(DirectX12Context* context) {
+	// Set the viewport and scissor rect.  This needs to be reset whenever the command list is reset.
+	context->mCommandList->RSSetViewports(1, &context->mScreenViewport);
+	context->mCommandList->RSSetScissorRects(1, &context->mScissorRect);
+}
+
+inline ID3D12Resource* dx12GetCurrentBackBuffer(DirectX12Context* context) {
+	return context->mSwapChainBuffer[context->mCurrBackBuffer].Get();
+}
+
+#endif // #if defined( __cplusplus )
+#endif // #define __D3DX12_CONTEXT_H__


### PR DESCRIPTION
Fixing issue with descriptor creation. Making flush function.

Moving swap buffers and execute commands. Removing flush lambda function.

Refactoring functions on resize (reset and resize swap buffers, create depth stencil buffer, reset command list and allocator)

Logging driver name.

Making native resizable window.

More context related functions to wrap common functionality. Creating reusable commands. Clearing warning.

Clearing comment